### PR TITLE
Update __init__.py

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -9,9 +9,13 @@ except ImportError:
         def emit(self, record):
             pass
 import re
+from distutils.version import LooseVersion
 
 import html5lib
-from html5lib.sanitizer import HTMLSanitizer
+if(LooseVersion(str(html5lib.__version__)) < LooseVersion('0.99999999')):
+    from html5lib.sanitizer import HTMLSanitizer
+ else:
+     from html5lib.filters.sanitizer import HTMLSanitizer
 from html5lib.serializer.htmlserializer import HTMLSerializer
 
 from . import callbacks as linkify_callbacks


### PR DESCRIPTION
html5lib moved location of sanitizer for ver 0.99999999 and up. This is a temporary fix, there is a PR https://github.com/mozilla/bleach/pull/215 that when merged will render this fix unnecessary and i can move back to using https://github.com/mozilla/bleach
